### PR TITLE
Fix NMSBiomeUtils fetching biome for incorrect y-level

### DIFF
--- a/nms/1.19.1/src/main/java/com/jeff_media/jefflib/internal/nms/v1_19_1/NMSBiomeUtils.java
+++ b/nms/1.19.1/src/main/java/com/jeff_media/jefflib/internal/nms/v1_19_1/NMSBiomeUtils.java
@@ -57,7 +57,7 @@ class NMSBiomeUtils {
         final BlockPos pos = new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ());
         final LevelChunk nmsChunk = ((CraftWorld) location.getWorld()).getHandle().getChunkAt(pos);
         if (nmsChunk != null) {
-            return nmsChunk.getNoiseBiome(pos.getX(), pos.getY(), pos.getZ());
+            return nmsChunk.getNoiseBiome(pos.getX() >> 2, pos.getY() >> 2, pos.getZ() >> 2);
         }
         return null;
     }

--- a/nms/1.19.2/src/main/java/com/jeff_media/jefflib/internal/nms/v1_19_2/NMSBiomeUtils.java
+++ b/nms/1.19.2/src/main/java/com/jeff_media/jefflib/internal/nms/v1_19_2/NMSBiomeUtils.java
@@ -58,7 +58,7 @@ class NMSBiomeUtils {
         final BlockPos pos = new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ());
         final LevelChunk nmsChunk = ((CraftWorld) location.getWorld()).getHandle().getChunkAt(pos);
         if (nmsChunk != null) {
-            return nmsChunk.getNoiseBiome(pos.getX(), pos.getY(), pos.getZ());
+            return nmsChunk.getNoiseBiome(pos.getX() >> 2, pos.getY() >> 2, pos.getZ() >> 2);
         }
         return null;
     }

--- a/nms/1.19.3/src/main/java/com/jeff_media/jefflib/internal/nms/v1_19_3/NMSBiomeUtils.java
+++ b/nms/1.19.3/src/main/java/com/jeff_media/jefflib/internal/nms/v1_19_3/NMSBiomeUtils.java
@@ -57,7 +57,7 @@ class NMSBiomeUtils {
         final BlockPos pos = new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ());
         final LevelChunk nmsChunk = ((CraftWorld) location.getWorld()).getHandle().getChunkAt(pos);
         if (nmsChunk != null) {
-            return nmsChunk.getNoiseBiome(pos.getX(), pos.getY(), pos.getZ());
+            return nmsChunk.getNoiseBiome(pos.getX() >> 2, pos.getY() >> 2, pos.getZ() >> 2);
         }
         return null;
     }

--- a/nms/1.19.4/src/main/java/com/jeff_media/jefflib/internal/nms/v1_19_4/NMSBiomeUtils.java
+++ b/nms/1.19.4/src/main/java/com/jeff_media/jefflib/internal/nms/v1_19_4/NMSBiomeUtils.java
@@ -57,7 +57,7 @@ class NMSBiomeUtils {
         final BlockPos pos = new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ());
         final LevelChunk nmsChunk = ((CraftWorld) location.getWorld()).getHandle().getChunkAt(pos);
         if (nmsChunk != null) {
-            return nmsChunk.getNoiseBiome(pos.getX(), pos.getY(), pos.getZ());
+            return nmsChunk.getNoiseBiome(pos.getX() >> 2, pos.getY() >> 2, pos.getZ() >> 2);
         }
         return null;
     }

--- a/nms/1.19/src/main/java/com/jeff_media/jefflib/internal/nms/v1_19/NMSBiomeUtils.java
+++ b/nms/1.19/src/main/java/com/jeff_media/jefflib/internal/nms/v1_19/NMSBiomeUtils.java
@@ -57,7 +57,7 @@ class NMSBiomeUtils {
         final BlockPos pos = new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ());
         final LevelChunk nmsChunk = ((CraftWorld) location.getWorld()).getHandle().getChunkAt(pos);
         if (nmsChunk != null) {
-            return nmsChunk.getNoiseBiome(pos.getX(), pos.getY(), pos.getZ());
+            return nmsChunk.getNoiseBiome(pos.getX() >> 2, pos.getY() >> 2, pos.getZ() >> 2);
         }
         return null;
     }

--- a/nms/1.20.1/src/main/java/com/jeff_media/jefflib/internal/nms/v1_20_1/NMSBiomeUtils.java
+++ b/nms/1.20.1/src/main/java/com/jeff_media/jefflib/internal/nms/v1_20_1/NMSBiomeUtils.java
@@ -57,7 +57,7 @@ class NMSBiomeUtils {
         final BlockPos pos = new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ());
         final LevelChunk nmsChunk = ((CraftWorld) location.getWorld()).getHandle().getChunkAt(pos);
         if (nmsChunk != null) {
-            return nmsChunk.getNoiseBiome(pos.getX(), pos.getY(), pos.getZ());
+            return nmsChunk.getNoiseBiome(pos.getX() >> 2, pos.getY() >> 2, pos.getZ() >> 2);
         }
         return null;
     }

--- a/nms/1.20.2/src/main/java/com/jeff_media/jefflib/internal/nms/v1_20_2/NMSBiomeUtils.java
+++ b/nms/1.20.2/src/main/java/com/jeff_media/jefflib/internal/nms/v1_20_2/NMSBiomeUtils.java
@@ -57,7 +57,7 @@ class NMSBiomeUtils {
         final BlockPos pos = new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ());
         final LevelChunk nmsChunk = ((CraftWorld) location.getWorld()).getHandle().getChunkAt(pos);
         if (nmsChunk != null) {
-            return nmsChunk.getNoiseBiome(pos.getX(), pos.getY(), pos.getZ());
+            return nmsChunk.getNoiseBiome(pos.getX() >> 2, pos.getY() >> 2, pos.getZ() >> 2);
         }
         return null;
     }

--- a/nms/1.20.4/src/main/java/com/jeff_media/jefflib/internal/nms/v1_20_4/NMSBiomeUtils.java
+++ b/nms/1.20.4/src/main/java/com/jeff_media/jefflib/internal/nms/v1_20_4/NMSBiomeUtils.java
@@ -57,7 +57,7 @@ class NMSBiomeUtils {
         final BlockPos pos = new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ());
         final LevelChunk nmsChunk = ((CraftWorld) location.getWorld()).getHandle().getChunkAt(pos);
         if (nmsChunk != null) {
-            return nmsChunk.getNoiseBiome(pos.getX(), pos.getY(), pos.getZ());
+            return nmsChunk.getNoiseBiome(pos.getX() >> 2, pos.getY() >> 2, pos.getZ() >> 2);
         }
         return null;
     }

--- a/nms/1_16_R2/src/main/java/com/jeff_media/jefflib/internal/nms/v1_16_R2/NMSBiomeUtils.java
+++ b/nms/1_16_R2/src/main/java/com/jeff_media/jefflib/internal/nms/v1_16_R2/NMSBiomeUtils.java
@@ -56,7 +56,7 @@ class NMSBiomeUtils {
         final BlockPosition pos = new BlockPosition(location.getBlockX(), location.getBlockY(), location.getBlockZ());
         final Chunk nmsChunk = ((CraftWorld) location.getWorld()).getHandle().getChunkAtWorldCoords(pos);
         if (nmsChunk != null) {
-            return nmsChunk.getBiomeIndex().getBiome(pos.getX(), pos.getY(), pos.getZ());
+            return nmsChunk.getBiomeIndex().getBiome(pos.getX() >> 2, pos.getY() >> 2, pos.getZ() >> 2);
         }
         return null;
     }

--- a/nms/1_16_R3/src/main/java/com/jeff_media/jefflib/internal/nms/v1_16_R3/NMSBiomeUtils.java
+++ b/nms/1_16_R3/src/main/java/com/jeff_media/jefflib/internal/nms/v1_16_R3/NMSBiomeUtils.java
@@ -56,7 +56,7 @@ class NMSBiomeUtils {
         final BlockPosition pos = new BlockPosition(location.getBlockX(), location.getBlockY(), location.getBlockZ());
         final Chunk nmsChunk = ((CraftWorld) location.getWorld()).getHandle().getChunkAtWorldCoords(pos);
         if (nmsChunk != null) {
-            return nmsChunk.getBiomeIndex().getBiome(pos.getX(), pos.getY(), pos.getZ());
+            return nmsChunk.getBiomeIndex().getBiome(pos.getX() >> 2, pos.getY() >> 2, pos.getZ() >> 2);
         }
         return null;
     }

--- a/nms/1_17_R1/src/main/java/com/jeff_media/jefflib/internal/nms/v1_17_R1/NMSBiomeUtils.java
+++ b/nms/1_17_R1/src/main/java/com/jeff_media/jefflib/internal/nms/v1_17_R1/NMSBiomeUtils.java
@@ -56,7 +56,7 @@ class NMSBiomeUtils {
         final BlockPos pos = new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ());
         final LevelChunk nmsChunk = ((CraftWorld) location.getWorld()).getHandle().getChunkAt(pos);
         if (nmsChunk != null) {
-            return nmsChunk.getBiomes().getNoiseBiome(pos.getX(), pos.getY(), pos.getZ());
+            return nmsChunk.getBiomes().getNoiseBiome(pos.getX() >> 2, pos.getY() >> 2, pos.getZ() >> 2);
         }
         return null;
     }

--- a/nms/1_18_R1/src/main/java/com/jeff_media/jefflib/internal/nms/v1_18_R1/NMSBiomeUtils.java
+++ b/nms/1_18_R1/src/main/java/com/jeff_media/jefflib/internal/nms/v1_18_R1/NMSBiomeUtils.java
@@ -56,7 +56,7 @@ class NMSBiomeUtils {
         final BlockPos pos = new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ());
         final LevelChunk nmsChunk = ((CraftWorld) location.getWorld()).getHandle().getChunkAt(pos);
         if (nmsChunk != null) {
-            return nmsChunk.getNoiseBiome(pos.getX(), pos.getY(), pos.getZ());
+            return nmsChunk.getNoiseBiome(pos.getX() >> 2, pos.getY() >> 2, pos.getZ() >> 2);
         }
         return null;
     }

--- a/nms/1_18_R2/src/main/java/com/jeff_media/jefflib/internal/nms/v1_18_R2/NMSBiomeUtils.java
+++ b/nms/1_18_R2/src/main/java/com/jeff_media/jefflib/internal/nms/v1_18_R2/NMSBiomeUtils.java
@@ -57,7 +57,7 @@ class NMSBiomeUtils {
         final BlockPos pos = new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ());
         final LevelChunk nmsChunk = ((CraftWorld) location.getWorld()).getHandle().getChunkAt(pos);
         if (nmsChunk != null) {
-            return nmsChunk.getNoiseBiome(pos.getX(), pos.getY(), pos.getZ());
+            return nmsChunk.getNoiseBiome(pos.getX() >> 2, pos.getY() >> 2, pos.getZ() >> 2);
         }
         return null;
     }


### PR DESCRIPTION
Apparently, biomes are only stored every 4 blocks in each direction. The slight change made to the coordinate calculation fixes the y level.