### PR TITLE
Fix wrong PlayerJumpEvent being used

### DIFF
--- a/paper-hacks/pom.xml
+++ b/paper-hacks/pom.xml
@@ -49,6 +49,11 @@
             <version>1.20.4-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.jeff-media.jefflib</groupId>
+            <artifactId>jefflib-core</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/paper-hacks/src/main/java/com/jeff_media/jefflib/events/PaperPlayerJumpEventListener.java
+++ b/paper-hacks/src/main/java/com/jeff_media/jefflib/events/PaperPlayerJumpEventListener.java
@@ -17,7 +17,6 @@
 
 package com.jeff_media.jefflib.events;
 
-import com.destroystokyo.paper.event.player.PlayerJumpEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;


### PR DESCRIPTION
In PaperPlayerJumpEventListener, the ownEvent type is `com.destroystokyo.paper.event.player.PlayerJumpEvent` instead of `com.jeff_media.jefflib.events.PlayerJumpEvent`